### PR TITLE
Workaround for Tapioca DSL with RuntimeGeneric

### DIFF
--- a/lib/public/repositories/base.rb
+++ b/lib/public/repositories/base.rb
@@ -23,6 +23,8 @@ module ResourceRegistry
 
       sig { returns(T.untyped) }
       def self.entity
+        return nil if defined?(Tapioca)
+
         T.unsafe(const_get(:Entity)).inner_type[:fixed]
       end
 


### PR DESCRIPTION
Since this `self.entity` needs RuntimeGeneric and it's evaluated by `tapioca dsl` this is triggering an incompatible error with how RuntimeGeneric works.

This PR addresses it by early returning in this method when Tapioca is evaluating.

Not very elegant but it makes the trick
