### PR TITLE
Adds new method to versions

### DIFF
--- a/lib/public/versions.rb
+++ b/lib/public/versions.rb
@@ -25,6 +25,19 @@ module ResourceRegistry
       find(name) || raise("Version '#{name}' not found")
     end
 
+    sig { params(name: String).returns(T.nilable(Version)) }
+    def find_next(name)
+      version = find!(name)
+      index = T.must(sorted_versions.index(version))
+
+      sorted_versions[index + 1]
+    end
+
+    sig { returns(T::Array[Version]) }
+    def sorted_versions
+      versions.sort
+    end
+
     private
 
     sig { returns(T::Array[Version]) }

--- a/lib/public/versions/version.rb
+++ b/lib/public/versions/version.rb
@@ -26,6 +26,11 @@ module ResourceRegistry
       def matches?(str)
         [name, *aliases].include?(str)
       end
+
+      sig { params(other: Version).returns(T.nilable(Integer)) }
+      def <=>(other)
+        name <=> other.name
+      end
     end
   end
 end

--- a/spec/public/versions_spec.rb
+++ b/spec/public/versions_spec.rb
@@ -6,12 +6,14 @@ require_relative '../../lib/public/versions'
 
 RSpec.describe ResourceRegistry::Versions do
   subject do
-    described_class.new(
-      versions: [
-        ResourceRegistry::Versions::Version.new('2024-01-01'),
-        ResourceRegistry::Versions::Version.new('2024-04-01', aliases: 'stable')
-      ]
-    )
+    described_class.new(versions: versions)
+  end
+
+  let(:versions) do
+    [
+      ResourceRegistry::Versions::Version.new('2024-01-01'),
+      ResourceRegistry::Versions::Version.new('2024-04-01', aliases: 'stable')
+    ]
   end
 
   describe '#find!' do
@@ -40,6 +42,40 @@ RSpec.describe ResourceRegistry::Versions do
 
     it 'returns a version with an alias' do
       expect(subject.find!('stable').to_s).to eq('2024-04-01')
+    end
+  end
+
+  describe '#find_next' do
+    context 'when given an old version' do
+      it 'returns the following version' do
+        expect(subject.find_next('2024-01-01').to_s).to eq('2024-04-01')
+      end
+    end
+
+    context 'when given the last version' do
+      it 'does not returns a version' do
+        expect(subject.find_next('2024-04-01')).to be_nil
+      end
+    end
+
+    context 'when given a random value' do
+      it 'does not returns a version' do
+        expect(subject.find_next('2024-04-01')).to be_nil
+      end
+    end
+
+    context 'when given a list of unsorted versions' do
+      let(:versions) do
+        [
+          ResourceRegistry::Versions::Version.new('2024-03-01', aliases: 'stable'),
+          ResourceRegistry::Versions::Version.new('2024-04-01', aliases: 'deprecated'),
+          ResourceRegistry::Versions::Version.new('2024-02-01')
+        ]
+      end
+
+      it 'orders and returns the following version' do
+        expect(subject.find_next('2024-02-01').to_s).to eq('2024-03-01')
+      end
     end
   end
 end


### PR DESCRIPTION
## 🚪 Why?

To be able to find the next version when given a specific version.

We found a use-case when trying to get the next version to generate the changelog. 
In the changelog, when we want to generate the changelog for version 2025-01-01, for example, we would need to get the version changes from version 2024-10-01, so we made this method in order to make it dynamic so we do not have to manually change these methods and you can give the changelog generator any version to generate its changelog.

## 🔑 What?

Adds new method that, given a version, sorts the versions array by name and finds the next newer version.
