### PR TITLE
Allow filter versions within a range

### DIFF
--- a/lib/public/versions.rb
+++ b/lib/public/versions.rb
@@ -38,6 +38,17 @@ module ResourceRegistry
       versions.sort
     end
 
+    sig do
+      params(from: T.nilable(String), to: T.nilable(String)).returns(
+        T::Array[ResourceRegistry::Versions::Version]
+      )
+    end
+    def in_range(from, to)
+      from = find!(from) unless from.nil?
+      to = find!(to) unless to.nil?
+      versions.select { |version| (from.nil? || version >= from) && (to.nil? || version <= to) }
+    end
+
     private
 
     sig { returns(T::Array[Version]) }

--- a/lib/public/versions/version.rb
+++ b/lib/public/versions/version.rb
@@ -31,6 +31,16 @@ module ResourceRegistry
       def <=>(other)
         name <=> other.name
       end
+
+      sig { params(other: Version).returns(T::Boolean) }
+      def >=(other)
+        name >= other.name
+      end
+
+      sig { params(other: Version).returns(T::Boolean) }
+      def <=(other)
+        name <= other.name
+      end
     end
   end
 end

--- a/spec/public/versions_spec.rb
+++ b/spec/public/versions_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe ResourceRegistry::Versions do
 
     context 'when given a random value' do
       it 'does not returns a version' do
-        expect(subject.find_next('2024-04-01')).to be_nil
+        expect { subject.find_next('2025-04-01') }.to raise_error(RuntimeError, 'Version \'2025-04-01\' not found')
       end
     end
 
@@ -75,6 +75,45 @@ RSpec.describe ResourceRegistry::Versions do
 
       it 'orders and returns the following version' do
         expect(subject.find_next('2024-02-01').to_s).to eq('2024-03-01')
+      end
+    end
+  end
+
+  describe '#in_range' do
+    let(:versions) do
+      [
+        ResourceRegistry::Versions::Version.new('2024-01-01'),
+        ResourceRegistry::Versions::Version.new('2024-04-28'),
+        ResourceRegistry::Versions::Version.new('2024-09-20'),
+        ResourceRegistry::Versions::Version.new('2025-01-09')
+      ]
+    end
+
+    it 'filters versions by >= from and <= to' do
+      expect(subject.in_range('2024-04-28', '2024-09-20').count).to eq(2)
+    end
+
+    context 'with only from' do
+      it 'filters versions by >= from' do
+        expect(subject.in_range('2024-04-28', nil).count).to eq(3)
+      end
+    end
+
+    context 'with only to' do
+      it 'filters versions by <= to' do
+        expect(subject.in_range(nil, '2024-09-20').count).to eq(3)
+      end
+    end
+
+    context 'with unexisting version' do
+      it 'raises error with wrong name' do
+        expect { subject.in_range('2022-01-01', '2022-01-01') }.to raise_error(RuntimeError, 'Version \'2022-01-01\' not found')
+      end
+    end
+
+    context 'without from and to' do
+      it 'does not apply any filter' do
+        expect(subject.in_range(nil, nil).count).to eq(4)
       end
     end
   end


### PR DESCRIPTION
## 🚪 Why?

[why]: # (✍️ _What needs is this Pull Request solving or how is it improving the product?_)
For Public APi automatic testing epic we will need to read a list of Version within a range

## 🔑 What?

[what]: # (✍️ _What changes is this Pull Request introducing in the code?_) 
Allow filtering Versions by range using the name.
In Public API we are using dates as names i.e 2024-01-01, but it will work the same with SemVer because it will use alphabet comparison.

