### PR TITLE
Support Version object in Versions#find_next

### DIFF
--- a/lib/resource_registry/versions.rb
+++ b/lib/resource_registry/versions.rb
@@ -22,9 +22,14 @@ module ResourceRegistry
       find(name) || raise("Version '#{name}' not found")
     end
 
-    sig { params(name: String).returns(T.nilable(Version)) }
-    def find_next(name)
-      version = find!(name)
+    sig do
+      params(name_or_version: T.any(String, Version)).returns(
+        T.nilable(Version)
+      )
+    end
+    def find_next(name_or_version)
+      version =
+        name_or_version.is_a?(String) ? find!(name_or_version) : name_or_version
       index = T.must(sorted_versions.index(version))
 
       sorted_versions[index + 1]

--- a/spec/resource_registry/versions_spec.rb
+++ b/spec/resource_registry/versions_spec.rb
@@ -51,11 +51,27 @@ RSpec.describe ResourceRegistry::Versions do
       it "returns the following version" do
         expect(subject.find_next("2024-01-01").to_s).to eq("2024-04-01")
       end
+
+      context "when given a version object" do
+        it "returns the following version" do
+          version = subject.find!("2024-01-01")
+
+          expect(subject.find_next(version).to_s).to eq("2024-04-01")
+        end
+      end
     end
 
     context "when given the last version" do
       it "does not returns a version" do
         expect(subject.find_next("2024-04-01")).to be_nil
+      end
+
+      context "when given a version object" do
+        it "does not returns a version" do
+          version = subject.find!("2024-04-01")
+
+          expect(subject.find_next(version)).to be_nil
+        end
       end
     end
 


### PR DESCRIPTION
We want to incentivate typing and use `Versions::Version` object instead of `String`

Once we are dealing with `Version`s, it does not make sense to convert it back to a String to use this method. Hence, we support the `Version` object

