### PR TITLE
Improve `fetch_for_repository` performance

### DIFF
--- a/lib/resource_registry/registry.rb
+++ b/lib/resource_registry/registry.rb
@@ -49,7 +49,7 @@ module ResourceRegistry
       ).returns(T.nilable(Resource))
     end
     def fetch_for_repository(repository_class)
-      fetch_all.values.find { |r| r.repository_raw == repository_class.to_s }
+      resources_by_raw_repository[repository_class.to_s]
     end
 
     alias find_for_repository fetch_for_repository
@@ -77,6 +77,15 @@ module ResourceRegistry
 
     sig { returns(T::Hash[String, Resource]) }
     attr_accessor :resources
+
+    sig { returns(T::Hash[String, Resource]) }
+    def resources_by_raw_repository
+      @resources_by_raw_repository ||=
+        T.let(
+          resources.values.index_by(&:repository_raw),
+          T.nilable(T::Hash[String, Resource])
+        )
+    end
 
     sig { params(resources: T::Array[Resource]).returns(T::Boolean) }
     def duplicated_identifier?(resources)

--- a/lib/resource_registry/registry.rb
+++ b/lib/resource_registry/registry.rb
@@ -1,5 +1,5 @@
+# typed: strict
 # frozen_string_literal: true
-# typed: false
 
 require_relative "resource"
 require_relative "capabilities/capability_config"
@@ -49,8 +49,10 @@ module ResourceRegistry
       ).returns(T.nilable(Resource))
     end
     def fetch_for_repository(repository_class)
-      fetch_all.values.find { |r| r.repository == repository_class }
+      fetch_all.values.find { |r| r.repository_raw == repository_class.to_s }
     end
+
+    alias find_for_repository fetch_for_repository
 
     sig { returns(T::Hash[String, Resource]) }
     def fetch_all
@@ -69,15 +71,6 @@ module ResourceRegistry
       fetch_all.values.select do |resource|
         capabilities_set <= resource.capabilities.keys.to_set
       end
-    end
-
-    sig do
-      params(
-        repository: T::Class[ResourceRegistry::Repositories::Base[T.untyped]]
-      ).returns(T.nilable(Resource))
-    end
-    def find_by_repository(repository)
-      fetch_all.values.find { |resource| resource.repository == repository }
     end
 
     private

--- a/lib/resource_registry/resource.rb
+++ b/lib/resource_registry/resource.rb
@@ -210,7 +210,7 @@ module ResourceRegistry
     def dump
       {
         "identifier" => identifier,
-        "repository" => repository.to_s,
+        "repository" => repository_raw,
         "description" => description,
         "relationships" => relationships.values.map(&:dump),
         "capabilities" =>


### PR DESCRIPTION
Calling `Resource#repository` produces a call to `safe_constantize` on the `repository_raw` string. Such calls are expensive because they trigger a loading cascade of other constants. In this case, it's also unnecessary since you can find repositories by comparing the strings directly, so we bypass the need for it completely.

We've also made the method more scalable for successive calls by creating an appropriate hash index for direct `repository_raw` lookups.

<img width="1504" alt="Captura de pantalla 2024-12-05 a las 12 16 08" src="https://github.com/user-attachments/assets/95f98e7c-a3b1-42c3-b4bb-3b6af39bb0df">
