### PR TITLE
Add enum method in Property

### DIFF
--- a/lib/schema_registry/property.rb
+++ b/lib/schema_registry/property.rb
@@ -79,6 +79,11 @@ module SchemaRegistry
     end
 
     sig { returns(T::Boolean) }
+    def enum?
+      enum_values.present?
+    end
+
+    sig { returns(T::Boolean) }
     def value_object?
       !!type_name.to_s.split("::").any?("ValueObjects")
     end


### PR DESCRIPTION
Right now the check to know if something's an enum requires us to check `enum_values.any?` or similar formulas. Different parts of the consumer code implement this check different, some even wrong. Instead we centralize this logic in a single place in the `Property` itself.